### PR TITLE
Fix summarization bug and init state

### DIFF
--- a/app/src/screens/UploadScreen/index.tsx
+++ b/app/src/screens/UploadScreen/index.tsx
@@ -46,7 +46,8 @@ console.log('WHISPER_API_ENDPOINT:', WHISPER_API_ENDPOINT);
  * @returns {JSX.Element} A React Native component.
  */
 const UploadScreen = () => {
-  const [transcription, setTranscription] = useState<string | null>(transcript);
+  // initialize the transcription state without a default value
+  const [transcription, setTranscription] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
   const [allResults, setAllResults] = useState<any[]>([]);

--- a/server/WhisperFlask/app.py
+++ b/server/WhisperFlask/app.py
@@ -41,11 +41,13 @@ def process_audio_file():
                 segment_file_path = os.path.join(os.getcwd(), f"segment_{i}.mp3")
                 segment.export(segment_file_path, format='mp3')
 
-                # transcribe each segment of audio separately
+                # transcribe each segment of audio separately. transcribe_audio
+                # is expected to return a dictionary that always includes a
+                # "raw" key containing the transcription text.
                 transcript = transcribe_audio(segment_file_path)
 
-                # summarize the transcription
-                summary = summarize_transcription(transcript)
+                # summarize the transcription using the raw text
+                summary = summarize_transcription(transcript["raw"])
 
                 # write notes from the summary
                 notes = write_notes(summary)

--- a/server/WhisperFlask/process_audio.py
+++ b/server/WhisperFlask/process_audio.py
@@ -55,7 +55,12 @@ def chatgpt3(userinput, temperature=0.6, frequency_penalty=0, presence_penalty=0
 
 
 def transcribe_audio(audio_file_path):
-    # This function will send the audio file to Whisper ASR API and return the transcription
+    """Transcribe the given audio file using OpenAI Whisper ASR.
+
+    Returns a dictionary with a single key "raw" containing the raw
+    transcription text so that callers can safely access
+    ``transcript["raw"]``.
+    """
     with open(audio_file_path, 'rb') as audio_file:
         transcription = openai.Audio.transcribe("whisper-1", audio_file)
     return {'raw': transcription.text}


### PR DESCRIPTION
## Summary
- fix usage of transcription dictionary in Flask app
- initialize transcription state properly in UploadScreen
- clarify that `transcribe_audio` returns a dictionary with a `raw` key

## Testing
- `yarn test` *(fails: package not in lockfile)*